### PR TITLE
add error boundary and auto reload

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -73,7 +73,8 @@
       "import/extensions": [
         "error",
         "never"
-      ]
+      ],
+      "react/state-in-constructor": "off"
     },
     "overrides": [
       {

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -1,11 +1,29 @@
 import React from "react";
 
+import ErrorFallback from "./ErrorFallback";
 import SingleRoomEntrance from "./SingleRoomEntrance";
 import "./App.css";
 
+class ErrorBoundary extends React.Component {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    const { children } = this.props;
+    const { hasError } = this.state;
+    if (hasError) return <ErrorFallback />;
+    return children;
+  }
+}
+
 const App: React.FC = () => (
   <div className="App">
-    <SingleRoomEntrance />
+    <ErrorBoundary>
+      <SingleRoomEntrance />
+    </ErrorBoundary>
   </div>
 );
 

--- a/web/src/components/ErrorFallback.tsx
+++ b/web/src/components/ErrorFallback.tsx
@@ -1,0 +1,24 @@
+import React, { useEffect, useState } from "react";
+
+const ErrorFallback: React.FC = () => {
+  const [waitSec, setWaitSec] = useState(60);
+
+  useEffect(() => {
+    if (waitSec > 0) {
+      setTimeout(() => {
+        setWaitSec(waitSec - 1);
+      }, 1000);
+    } else {
+      window.location.reload();
+    }
+  });
+
+  return (
+    <div>
+      <h1>Unrecoverable error occurred.</h1>
+      <p>Will auto reload in {waitSec} sec.</p>
+    </div>
+  );
+};
+
+export default ErrorFallback;

--- a/web/src/hooks/useFaceImages.ts
+++ b/web/src/hooks/useFaceImages.ts
@@ -30,6 +30,18 @@ export const useFaceImages = (
   const [myImage, setMyImage] = useState<ImageUrl>();
   const [roomImages, setRoomImages] = useState<RoomImage[]>([]);
   const [networkStatus, updateNetworkStatus] = useState<NetworkStatus>();
+  const [fatalError, setFatalError] = useState<Error>();
+
+  if (fatalError) {
+    throw fatalError;
+  }
+  if (
+    networkStatus &&
+    (networkStatus.type === "NETWORK_ERROR" ||
+      networkStatus.type === "UNKNOWN_ERROR")
+  ) {
+    throw new Error("network error");
+  }
 
   useEffect(() => {
     const receiveData = (_peerId: number, data: unknown) => {
@@ -92,7 +104,7 @@ export const useFaceImages = (
         broadcastData(data);
       } catch (e) {
         console.error(e);
-        // TODO ErrorBoundary
+        setFatalError(e);
       }
     };
     loop();


### PR DESCRIPTION
This will show a fallback screen if an error is occurred. Possible errors are webcam permission rejection, network disconnection and other unknown errors.