### PR TITLE
add placeholder to status form

### DIFF
--- a/web/src/components/SingleRoom.tsx
+++ b/web/src/components/SingleRoom.tsx
@@ -63,6 +63,7 @@ const SingleRoom: React.FC<Props> = ({ roomId, userId }) => {
                 onChange={(e) => {
                   messageRef.current = e.target.value;
                 }}
+                placeholder="Enter message."
               />
             </form>
           </div>


### PR DESCRIPTION
This change adds a placeholder to the status form and prompts the user for a message.


<img width="210" alt="スクリーンショット 2020-04-12 22 21 54" src="https://user-images.githubusercontent.com/13297716/79069804-2742f300-7d0c-11ea-9378-3ab4bf699855.png">


Preview URL: https://codesandbox.io/s/github/monisoi/remote-faces/tree/feat/status-placeholder/web/