### PR TITLE
chore: track based and immutable stream

### DIFF
--- a/web/src/components/FaceImages.tsx
+++ b/web/src/components/FaceImages.tsx
@@ -52,7 +52,7 @@ const FaceImage = React.memo<{
           &#9673;
         </div>
       )}
-      {liveMode && !hasVideo && !hasAudio && (
+      {!obsoleted && liveMode && !stream && (
         <div className="FaceImages-live-indicator" title="Video On">
           &#9678;
         </div>

--- a/web/src/components/FaceImages.tsx
+++ b/web/src/components/FaceImages.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useRef, useEffect } from "react";
 
 import "./FaceImages.css";
 import { useFaceImages } from "../hooks/useFaceImages";
@@ -16,29 +16,14 @@ const FaceImage = React.memo<{
   stream?: MediaStream;
   unmuted?: boolean;
 }>(({ image, nickname, statusMesg, obsoleted, liveMode, stream, unmuted }) => {
-  const [hasVideo, setHasVideo] = useState(false);
-  const [hasAudio, setHasAudio] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   useEffect(() => {
     if (stream && videoRef.current) {
       videoRef.current.srcObject = stream;
     }
-    const checkStream = () => {
-      setHasVideo(!!stream && stream.getVideoTracks().length > 0);
-      setHasAudio(!!stream && stream.getAudioTracks().length > 0);
-    };
-    if (stream) {
-      stream.addEventListener("addtrack", checkStream);
-      stream.addEventListener("removetrack", checkStream);
-    }
-    checkStream();
-    return () => {
-      if (stream) {
-        stream.removeEventListener("addtrack", checkStream);
-        stream.removeEventListener("removetrack", checkStream);
-      }
-    };
   }, [stream]);
+  const hasVideo = !!stream && stream.getVideoTracks().length > 0;
+  const hasAudio = !!stream && stream.getAudioTracks().length > 0;
   return (
     <div className="FaceImages-card" style={{ opacity: obsoleted ? 0.2 : 1 }}>
       {liveMode && stream ? (
@@ -102,7 +87,7 @@ const FaceImages: React.FC<Props> = ({
     statusMesg,
     videoDeviceId
   );
-  const { myStream, streamMap } = useFaceVideos(
+  const { faceStream, faceStreamMap } = useFaceVideos(
     roomId,
     userId,
     liveType === "video" || liveType === "video+audio",
@@ -118,7 +103,7 @@ const FaceImages: React.FC<Props> = ({
         nickname={nickname}
         statusMesg={statusMesg}
         liveMode={liveType !== "off"}
-        stream={myStream || undefined}
+        stream={faceStream || undefined}
       />
       {roomImages.map((item) => (
         <FaceImage
@@ -128,7 +113,7 @@ const FaceImages: React.FC<Props> = ({
           statusMesg={item.info.message}
           obsoleted={item.obsoleted}
           liveMode={item.liveMode}
-          stream={streamMap[item.userId]}
+          stream={faceStreamMap[item.userId] || undefined}
           unmuted={liveType === "video+audio"}
         />
       ))}

--- a/web/src/components/FaceImages.tsx
+++ b/web/src/components/FaceImages.tsx
@@ -41,7 +41,7 @@ const FaceImage = React.memo<{
   }, [stream]);
   return (
     <div className="FaceImages-card" style={{ opacity: obsoleted ? 0.2 : 1 }}>
-      {stream ? (
+      {liveMode && stream ? (
         <video
           className="FaceImages-photo"
           ref={videoRef}

--- a/web/src/hooks/useFaceImages.ts
+++ b/web/src/hooks/useFaceImages.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 
 import { takePhoto } from "../media/capture";
 import { useRoomData, useBroadcastData } from "./useRoom";
@@ -50,29 +50,26 @@ export const useFaceImages = (
 
   const broadcastData = useBroadcastData(roomId, userId);
   const latestData = useRoomData<ImageData>(roomId, userId, isImageData);
-  const roomImage: RoomImage | undefined = useMemo(
-    () =>
-      latestData && {
+  useEffect(() => {
+    if (latestData) {
+      const roomImage = {
         ...latestData.data,
         userId: latestData.info.userId,
         received: Date.now(),
         obsoleted: false,
         liveMode: latestData.info.liveMode,
-      },
-    [latestData]
-  );
-  if (roomImage) {
-    const found = roomImages.find((item) => item.userId === roomImage.userId);
-    if (!found) {
-      setRoomImages([...roomImages, roomImage]);
-    } else if (found.received !== roomImage.received) {
-      setRoomImages(
-        roomImages.map((item) =>
+      };
+      setRoomImages((prev) => {
+        const found = prev.find((item) => item.userId === roomImage.userId);
+        if (!found) {
+          return [...prev, roomImage];
+        }
+        return prev.map((item) =>
           item.userId === roomImage.userId ? roomImage : item
-        )
-      );
+        );
+      });
     }
-  }
+  }, [latestData]);
 
   useEffect(() => {
     const checkObsoletedImage = () => {

--- a/web/src/hooks/useFaceImages.ts
+++ b/web/src/hooks/useFaceImages.ts
@@ -49,17 +49,17 @@ export const useFaceImages = (
   }
 
   const broadcastData = useBroadcastData(roomId, userId);
-  const result = useRoomData<ImageData>(roomId, userId, isImageData);
+  const latestData = useRoomData<ImageData>(roomId, userId, isImageData);
   const roomImage: RoomImage | undefined = useMemo(
     () =>
-      result && {
-        ...result.data,
-        userId: result.info.userId,
+      latestData && {
+        ...latestData.data,
+        userId: latestData.info.userId,
         received: Date.now(),
         obsoleted: false,
-        liveMode: result.info.liveMode,
+        liveMode: latestData.info.liveMode,
       },
-    [result]
+    [latestData]
   );
   if (roomImage) {
     const found = roomImages.find((item) => item.userId === roomImage.userId);

--- a/web/src/hooks/useFaceVideos.ts
+++ b/web/src/hooks/useFaceVideos.ts
@@ -17,6 +17,7 @@ const removeTrackWithNewStream = (
   track: MediaStreamTrack,
   stream: MediaStream | null
 ) => {
+  // XXX removeTrack doesn't remove from the result... a workaround
   // const newStream = stream ? stream.clone() : new MediaStream();
   // newStream.removeTrack(track);
   const newStream = new MediaStream();

--- a/web/src/hooks/useFaceVideos.ts
+++ b/web/src/hooks/useFaceVideos.ts
@@ -88,9 +88,9 @@ export const useFaceVideos = (
         addTrack(videoTrack);
         setFaceStream((prev) => addTrackWithNewStream(videoTrack, prev));
         dispose = () => {
-          disposeVideo();
-          removeTrack(videoTrack);
           setFaceStream((prev) => removeTrackWithNewStream(videoTrack, prev));
+          removeTrack(videoTrack);
+          disposeVideo();
         };
       })();
     }
@@ -111,9 +111,9 @@ export const useFaceVideos = (
         addTrack(audioTrack);
         setFaceStream((prev) => addTrackWithNewStream(audioTrack, prev));
         dispose = () => {
-          disposeAudio();
-          removeTrack(audioTrack);
           setFaceStream((prev) => removeTrackWithNewStream(audioTrack, prev));
+          removeTrack(audioTrack);
+          disposeAudio();
         };
       })();
     }

--- a/web/src/hooks/useFaceVideos.ts
+++ b/web/src/hooks/useFaceVideos.ts
@@ -59,8 +59,15 @@ export const useFaceVideos = (
       ...prev,
       [info.userId]: addTrackWithNewStream(track, prev[info.userId]),
     }));
-    // XXX we don't get "ended" event, so a workaround with "mute"
-    // but "mute" is dispatched occasionally, so timeout hack
+    track.addEventListener("ended", () => {
+      setFaceStreamMap((prev) => ({
+        ...prev,
+        [info.userId]: removeTrackWithNewStream(track, prev[info.userId]),
+      }));
+    });
+    // XXX we don't get "ended" event with removeTrack,
+    // so a workaround with "mute" but "mute" is dispatched occasionally,
+    // so use this timeout hack
     let timeout: NodeJS.Timeout;
     track.addEventListener("mute", () => {
       clearTimeout(timeout);

--- a/web/src/hooks/useRoom.ts
+++ b/web/src/hooks/useRoom.ts
@@ -1,24 +1,15 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 
-import {
-  PeerInfo,
-  ReceiveStream,
-  createRoom,
-  NetworkStatus,
-} from "../network/room";
+import { PeerInfo, createRoom, NetworkStatus } from "../network/room";
 
 type NetworkStatusListener = (status: NetworkStatus) => void;
 type DataListener = (data: unknown, info: PeerInfo) => void;
-type StreamListener = (
-  stream: MediaStream | null, // null for removing stream
-  info: Parameters<ReceiveStream>[1]
-) => void;
+type TrackListener = (track: MediaStreamTrack, info: PeerInfo) => void;
 type RoomEntry = {
   room: ReturnType<typeof createRoom>;
   networkStatusListeners: Set<NetworkStatusListener>;
   dataListeners: Set<DataListener>;
-  streamListeners: Set<StreamListener>;
-  myStream: MediaStream;
+  trackListeners: Set<TrackListener>;
   count: number;
 };
 const roomEntryMap = new Map<string, RoomEntry>();
@@ -27,15 +18,14 @@ const register = (
   userId: string,
   networkStatusListener?: NetworkStatusListener,
   dataListener?: DataListener,
-  streamListener?: StreamListener
+  trackListener?: TrackListener
 ) => {
   const roomEntryKey = `${roomId}_${userId}`;
   let entry = roomEntryMap.get(roomEntryKey);
   if (!entry) {
     const networkStatusListeners = new Set<NetworkStatusListener>();
     const dataListeners = new Set<DataListener>();
-    const streamListeners = new Set<StreamListener>();
-    const myStream = new MediaStream();
+    const trackListeners = new Set<TrackListener>();
     const updateNetworkStatus = (status: NetworkStatus) => {
       networkStatusListeners.forEach((listener) => {
         listener(status);
@@ -46,28 +36,23 @@ const register = (
         listener(data, info);
       });
     };
-    const receiveStream = (
-      stream: MediaStream | null,
-      info: Parameters<ReceiveStream>[1]
-    ) => {
-      streamListeners.forEach((listener) => {
-        listener(stream, info);
+    const receiveTrack = (track: MediaStreamTrack, info: PeerInfo) => {
+      trackListeners.forEach((listener) => {
+        listener(track, info);
       });
     };
     const room = createRoom(
       roomId,
       userId,
-      myStream,
       updateNetworkStatus,
       receiveData,
-      receiveStream
+      receiveTrack
     );
     entry = {
       room,
       networkStatusListeners,
       dataListeners,
-      streamListeners,
-      myStream,
+      trackListeners,
       count: 0,
     };
     roomEntryMap.set(roomEntryKey, entry);
@@ -78,9 +63,9 @@ const register = (
   if (dataListener) {
     entry.dataListeners.add(dataListener);
   }
-  if (streamListener) {
-    entry.streamListeners.add(streamListener);
-    if (entry.streamListeners.size === 1) {
+  if (trackListener) {
+    entry.trackListeners.add(trackListener);
+    if (entry.trackListeners.size === 1) {
       entry.room.enableLiveMode();
     }
   }
@@ -92,9 +77,9 @@ const register = (
     if (dataListener) {
       (entry as RoomEntry).dataListeners.delete(dataListener);
     }
-    if (streamListener) {
-      (entry as RoomEntry).streamListeners.delete(streamListener);
-      if ((entry as RoomEntry).streamListeners.size === 0) {
+    if (trackListener) {
+      (entry as RoomEntry).trackListeners.delete(trackListener);
+      if ((entry as RoomEntry).trackListeners.size === 0) {
         (entry as RoomEntry).room.disableLiveMode();
       }
     }
@@ -106,7 +91,8 @@ const register = (
   };
   return {
     broadcastData: entry.room.broadcastData,
-    myStream: entry.myStream,
+    addTrack: entry.room.addTrack,
+    removeTrack: entry.room.removeTrack,
     unregister,
   };
 };
@@ -150,18 +136,21 @@ export const useRoomData = <Data>(
   userId: string,
   isValidData: (data: unknown) => boolean
 ) => {
-  const [result, setResult] = useState<{ data: Data; info: PeerInfo }>();
+  const [latestData, setLatestData] = useState<{
+    data: Data;
+    info: PeerInfo;
+  }>();
   useEffect(() => {
     const dataListener = (data: unknown, info: PeerInfo) => {
       if (isValidData(data)) {
-        setResult({ data: data as Data, info });
+        setLatestData({ data: data as Data, info });
       }
       return false;
     };
     const { unregister } = register(roomId, userId, undefined, dataListener);
     return unregister;
   }, [roomId, userId, isValidData]);
-  return result;
+  return latestData;
 };
 
 export const useRoomMedia = (
@@ -169,38 +158,38 @@ export const useRoomMedia = (
   userId: string,
   enabled: boolean
 ) => {
-  const [myStream, setMyStream] = useState<MediaStream | null>(null);
-  const [streamList, setStreamList] = useState<
-    { stream: MediaStream; info: Parameters<ReceiveStream>[1] }[]
-  >([]);
+  const [functions, setFunctions] = useState<{
+    addTrack?: (track: MediaStreamTrack) => void;
+    removeTrack?: (track: MediaStreamTrack) => void;
+  }>({});
+  const [latestTrack, setLatestTrack] = useState<{
+    track: MediaStreamTrack;
+    info: PeerInfo;
+  } | null>(null);
   useEffect(() => {
     if (enabled) {
-      const streamListener = (
-        stream: MediaStream | null,
-        info: Parameters<ReceiveStream>[1]
-      ) => {
-        setStreamList((prev) => [
-          ...prev.filter((item) => item.info.userId !== info.userId),
-          ...(stream ? [{ stream, info }] : []),
-        ]);
+      const trackListener = (track: MediaStreamTrack, info: PeerInfo) => {
+        setLatestTrack({ track, info });
       };
-      const { myStream: myStreamToSet, unregister } = register(
+      const result = register(
         roomId,
         userId,
         undefined,
         undefined,
-        streamListener
+        trackListener
       );
-      setMyStream(myStreamToSet || null);
-      return unregister;
+      setFunctions({
+        addTrack: result.addTrack,
+        removeTrack: result.removeTrack,
+      });
+      return () => {
+        setFunctions({});
+        result.unregister();
+      };
     }
-    // noot enabled
-    setMyStream(null);
-    setStreamList([]);
+    // not enabled
+    setLatestTrack(null);
     return undefined;
   }, [roomId, userId, enabled]);
-  return {
-    myStream,
-    streamList,
-  };
+  return { ...functions, latestTrack };
 };

--- a/web/src/network/peerUtils.ts
+++ b/web/src/network/peerUtils.ts
@@ -80,12 +80,6 @@ export const createConnectionMap = () => {
   const getConnectedPeerIds = () =>
     Array.from(map.keys()).filter((k) => map.get(k)?.connected);
 
-  const getLivePeerIds = () =>
-    Array.from(map.keys()).filter((k) => {
-      const value = map.get(k);
-      return value && value.connected && value.liveMode;
-    });
-
   const forEachConnectedConns = (
     callback: (conn: Peer.DataConnection) => void
   ) => {
@@ -122,7 +116,6 @@ export const createConnectionMap = () => {
     hasConn,
     delConn,
     getConnectedPeerIds,
-    getLivePeerIds,
     forEachConnectedConns,
     forEachLiveConns,
     clearAll,

--- a/web/src/network/room.ts
+++ b/web/src/network/room.ts
@@ -254,7 +254,6 @@ export const createRoom = (
     peer.on("error", (err) => {
       if (err.type === "unavailable-id") {
         myPeer = null;
-        lastBroadcastData = null;
         peer.destroy();
         initMyPeer(index + 1);
       } else if (err.type === "peer-unavailable") {
@@ -293,7 +292,6 @@ export const createRoom = (
       if (myPeer === peer) {
         console.log("initMyPeer closed, re-initializing", index);
         myPeer = null;
-        lastBroadcastData = null;
         setTimeout(initMyPeer, 10 * 1000);
       } else {
         console.log("initMyPeer closed, ignoring", index);
@@ -322,7 +320,6 @@ export const createRoom = (
     }
     const oldPeer = myPeer;
     myPeer = null;
-    lastBroadcastData = null;
     oldPeer.destroy();
     initMyPeer();
   };
@@ -365,8 +362,9 @@ export const createRoom = (
   };
 
   const removeTrack = (track: MediaStreamTrack) => {
-    if (!localStream) return;
-    localStream.removeTrack(track);
+    if (localStream) {
+      localStream.removeTrack(track);
+    }
     connMap.forEachLiveConns(async (conn) => {
       const senders = conn.peerConnection.getSenders();
       const sender = senders.find((s) => s.track === track);

--- a/web/src/network/room.ts
+++ b/web/src/network/room.ts
@@ -68,10 +68,9 @@ export const createRoom = (
       lastBroadcastData = data;
     }
     const peers = connMap.getConnectedPeerIds();
-    const livePeers = connMap.getLivePeerIds();
     connMap.forEachConnectedConns((conn) => {
       try {
-        conn.send({ userId, data, peers, liveMode, livePeers });
+        conn.send({ userId, data, peers, liveMode });
       } catch (e) {
         console.error("broadcastData", e);
       }
@@ -180,7 +179,6 @@ export const createRoom = (
           data: lastBroadcastData,
           peers: connMap.getConnectedPeerIds(),
           liveMode,
-          livePeers: connMap.getLivePeerIds(),
         });
       }
     });

--- a/web/src/network/room.ts
+++ b/web/src/network/room.ts
@@ -340,6 +340,9 @@ export const createRoom = (
       return;
     }
     liveMode = false;
+    if (localStream) {
+      localStream.getTracks().forEach(removeTrack);
+    }
     localStream = null;
     broadcastData(lastBroadcastData);
   };
@@ -362,9 +365,8 @@ export const createRoom = (
   };
 
   const removeTrack = (track: MediaStreamTrack) => {
-    if (localStream) {
-      localStream.removeTrack(track);
-    }
+    if (!localStream) return;
+    localStream.removeTrack(track);
     connMap.forEachLiveConns(async (conn) => {
       const senders = conn.peerConnection.getSenders();
       const sender = senders.find((s) => s.track === track);

--- a/web/src/network/room.ts
+++ b/web/src/network/room.ts
@@ -374,7 +374,7 @@ export const createRoom = (
     });
   };
 
-  const addAllStreamTracks = async (conn: Peer.DataConnection) => {
+  const addAllStreamTracks = (conn: Peer.DataConnection) => {
     if (!localStream) return;
     localStream.getTracks().forEach((track) => {
       try {
@@ -390,7 +390,7 @@ export const createRoom = (
     });
   };
 
-  const removeAllStreamTracks = async (conn: Peer.DataConnection) => {
+  const removeAllStreamTracks = (conn: Peer.DataConnection) => {
     const senders = conn.peerConnection.getSenders();
     senders.forEach((sender) => {
       if (sender.track) {


### PR DESCRIPTION
Close #63.


- [x] video+audio -> video only doesn't change the indicator (there are no remove events...)
- [x] going offline still shows available indicator (for two minutes at most)
- [x] can't auto re-connect in live mode when underlying peer reconnects (after two minutes, it works)


Preview URL: https://codesandbox.io/s/github/dai-shi/remote-faces/tree/chore/network-track-centric/web/
