### PR TITLE
fix: re-enable live-mode

### DIFF
--- a/web/src/network/room.ts
+++ b/web/src/network/room.ts
@@ -391,6 +391,7 @@ export const createRoom = (
               mediaTypes: connMap.getMediaTypes(conn),
             };
             conn.peerConnection.getReceivers().forEach((receiver) => {
+              if (receiver.track.readyState !== "live") return;
               receiveTrack(
                 setupTrackStopOnLongMute(receiver.track, conn.peerConnection),
                 info


### PR DESCRIPTION
close #131.

There were an obvious bug with useEffect, a hard bug in receiveTrack, and a bug in disposeStream.


Preview URL: https://codesandbox.io/s/github/dai-shi/remote-faces/tree/fix/re-enable-live-mode/web/
