### PR TITLE
feat: send data on init

### DIFF
--- a/web/src/hooks/useFaceImages.ts
+++ b/web/src/hooks/useFaceImages.ts
@@ -61,9 +61,9 @@ export const useFaceImages = (
   useRoomNewPeer(
     roomId,
     userId,
-    useCallback(async function* getInitialDataIterator() {
-      if (!lastDataRef.current) return;
-      yield lastDataRef.current;
+    useCallback(async () => {
+      if (!lastDataRef.current) return null;
+      return lastDataRef.current;
     }, [])
   );
 

--- a/web/src/hooks/useGoBoard.ts
+++ b/web/src/hooks/useGoBoard.ts
@@ -58,9 +58,9 @@ export const useGoBoard = (
   useRoomNewPeer(
     roomId,
     userId,
-    useCallback(async function* getInitialDataIterator() {
-      if (!lastDataRef.current) return;
-      yield lastDataRef.current;
+    useCallback(async () => {
+      if (!lastDataRef.current) return null;
+      return lastDataRef.current;
     }, [])
   );
 

--- a/web/src/network/peerUtils.ts
+++ b/web/src/network/peerUtils.ts
@@ -73,6 +73,12 @@ export const createConnectionMap = () => {
 
   const hasConn = (peerId: string) => map.has(peerId);
 
+  const getConn = (peerId: string) => {
+    const value = map.get(peerId);
+    if (!value) return null;
+    return value.conn;
+  };
+
   const delConn = (conn: Peer.DataConnection) => {
     const value = map.get(conn.peer);
     if (value && value.conn === conn) {
@@ -124,6 +130,7 @@ export const createConnectionMap = () => {
     setMediaTypes,
     getMediaTypes,
     hasConn,
+    getConn,
     delConn,
     getConnectedPeerIds,
     forEachConnectedConns,


### PR DESCRIPTION
This changes the way to handle initial data on new peer.
Previously, we used async generator and it can be confusing.
This exports `sendData` from room.ts and it would be more flexible.
MomentaryChat is also simplified on init and UX would be better. (Network cost could be higher. `TODO` )


Preview URL: https://codesandbox.io/s/github/dai-shi/remote-faces/tree/feat/send-data-on-init/web/
