### PR TITLE
Refactor: Associate mediaType with track

### DIFF
--- a/web/src/hooks/useFaceVideos.ts
+++ b/web/src/hooks/useFaceVideos.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 
-import { getFaceVideoStream, isVideoTrackFaceSize } from "../media/video";
+import { getFaceVideoStream } from "../media/video";
 import { getAudioStream } from "../media/audio";
 import { useRoomMedia } from "./useRoom";
 
@@ -43,9 +43,6 @@ export const useFaceVideos = (
   }, []);
 
   const onTrack = useCallback(async (track, info) => {
-    if (track.kind === "video" && !(await isVideoTrackFaceSize(track))) {
-      return;
-    }
     const disposeStream = (s: MediaStream) => {
       if (isMounted.current) {
         setFaceStreamMap((prev) => {

--- a/web/src/hooks/useFaceVideos.ts
+++ b/web/src/hooks/useFaceVideos.ts
@@ -106,7 +106,7 @@ export const useFaceVideos = (
           addTrackToStream(videoTrack, prev, disposeStream)
         );
         dispose = () => {
-          removeVideoTrack(videoTrack);
+          removeVideoTrack();
           disposeVideo();
           // XXX we need to manually dispatch ended event, why?
           videoTrack.dispatchEvent(new Event("ended"));
@@ -137,7 +137,7 @@ export const useFaceVideos = (
           addTrackToStream(audioTrack, prev, disposeStream)
         );
         dispose = () => {
-          removeAudioTrack(audioTrack);
+          removeAudioTrack();
           disposeAudio();
           // XXX we need to manually dispatch ended event, why?
           audioTrack.dispatchEvent(new Event("ended"));

--- a/web/src/hooks/useRoom.ts
+++ b/web/src/hooks/useRoom.ts
@@ -247,7 +247,7 @@ export const useRoomMedia = (
 ) => {
   const [functions, setFunctions] = useState<{
     addTrack?: (track: MediaStreamTrack) => void;
-    removeTrack?: (track: MediaStreamTrack) => void;
+    removeTrack?: () => void;
   }>({});
   useEffect(() => {
     let cleanup = () => {};
@@ -259,8 +259,7 @@ export const useRoomMedia = (
         setFunctions({
           addTrack: (track: MediaStreamTrack) =>
             result.addTrack(mediaType, track),
-          removeTrack: (track: MediaStreamTrack) =>
-            result.removeTrack(mediaType, track),
+          removeTrack: () => result.removeTrack(mediaType),
         });
         cleanup = () => {
           setFunctions({});

--- a/web/src/hooks/useRoom.ts
+++ b/web/src/hooks/useRoom.ts
@@ -42,7 +42,11 @@ const createRoomEntry = async (
       listener(data, info);
     });
   };
-  const receiveTrack = (track: MediaStreamTrack, info: PeerInfo) => {
+  const receiveTrack = (
+    mediaType: string,
+    track: MediaStreamTrack,
+    info: PeerInfo
+  ) => {
     trackListeners.forEach(({ listener }) => {
       listener(track, info);
     });

--- a/web/src/hooks/useScreenShare.ts
+++ b/web/src/hooks/useScreenShare.ts
@@ -1,14 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 
-import { isVideoTrackFaceSize } from "../media/video";
 import { getScreenStream } from "../media/screen";
 import { useRoomMedia } from "./useRoom";
-
-const isScreenTrack = async (track: MediaStreamTrack) => {
-  if (track.kind !== "video") return false;
-  const isFaceSize = await isVideoTrackFaceSize(track);
-  return !isFaceSize;
-};
 
 export const useScreenShare = (
   roomId: string,
@@ -31,7 +24,6 @@ export const useScreenShare = (
   }, []);
 
   const onTrack = useCallback(async (track, info) => {
-    if (!(await isScreenTrack(track))) return;
     setScreenStreamMap((prev) => ({
       ...prev,
       [info.userId]: new MediaStream([track]),

--- a/web/src/hooks/useScreenShare.ts
+++ b/web/src/hooks/useScreenShare.ts
@@ -68,7 +68,7 @@ export const useScreenShare = (
         addTrack(track);
         setScreenStream(result.stream);
         dispose = () => {
-          removeTrack(track);
+          removeTrack();
           result.dispose();
           setScreenStream(null);
           setEnabled(false);

--- a/web/src/hooks/useVideoShare.ts
+++ b/web/src/hooks/useVideoShare.ts
@@ -1,13 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 
-import { getVideoStream, isVideoTrackFaceSize } from "../media/video";
+import { getVideoStream } from "../media/video";
 import { useRoomMedia } from "./useRoom";
-
-const isVideoTrack = async (track: MediaStreamTrack) => {
-  if (track.kind !== "video") return false;
-  const isFaceSize = await isVideoTrackFaceSize(track);
-  return !isFaceSize;
-};
 
 export const useVideoShare = (
   roomId: string,
@@ -31,7 +25,6 @@ export const useVideoShare = (
   }, []);
 
   const onTrack = useCallback(async (track, info) => {
-    if (!(await isVideoTrack(track))) return;
     setVideoStreamMap((prev) => ({
       ...prev,
       [info.userId]: new MediaStream([track]),

--- a/web/src/hooks/useVideoShare.ts
+++ b/web/src/hooks/useVideoShare.ts
@@ -64,7 +64,7 @@ export const useVideoShare = (
         addTrack(track);
         setVideoStream(result.stream);
         dispose = () => {
-          removeTrack(track);
+          removeTrack();
           result.dispose();
           setVideoStream(null);
           setEnabled(false);

--- a/web/src/media/video.ts
+++ b/web/src/media/video.ts
@@ -62,33 +62,3 @@ export const getFaceVideoStream = async (deviceId?: string) => {
     dispose,
   };
 };
-
-const checkVideTrackFaceSize = async (track: MediaStreamTrack) => {
-  try {
-    const video = document.createElement("video");
-    video.srcObject = new MediaStream([track]);
-    for (let i = 0; i < 50; i += 1) {
-      // eslint-disable-next-line no-await-in-loop
-      await sleep(100);
-      const width = video.videoWidth;
-      const height = video.videoHeight;
-      if (width > 0 && height > 0) {
-        return width === 72 && height === 72;
-      }
-    }
-    return true; // fallback to true
-  } catch (e) {
-    return true; // fallback to true
-  }
-};
-
-const videoTrackFaceSizeMap = new WeakMap<MediaStreamTrack, Promise<boolean>>();
-
-export const isVideoTrackFaceSize = (track: MediaStreamTrack) => {
-  if (videoTrackFaceSizeMap.has(track)) {
-    return videoTrackFaceSizeMap.get(track) as Promise<boolean>;
-  }
-  const promise = checkVideTrackFaceSize(track);
-  videoTrackFaceSizeMap.set(track, promise);
-  return promise;
-};

--- a/web/src/network/common.ts
+++ b/web/src/network/common.ts
@@ -37,6 +37,6 @@ export type CreateRoom = (
   sendData: (data: unknown, peerIndex: number) => void;
   acceptMediaTypes: (mediaTypes: string[]) => void;
   addTrack: (mediaType: string, track: MediaStreamTrack) => void;
-  removeTrack: (mediaType: string, track: MediaStreamTrack) => void;
+  removeTrack: (mediaType: string) => void;
   dispose: () => void;
 }>;

--- a/web/src/network/common.ts
+++ b/web/src/network/common.ts
@@ -19,7 +19,11 @@ export type PeerInfo = {
 };
 type NotifyNewPeer = (peerIndex: number) => void;
 type ReceiveData = (data: unknown, info: PeerInfo) => void;
-type ReceiveTrack = (track: MediaStreamTrack, info: PeerInfo) => void;
+type ReceiveTrack = (
+  mediaType: string,
+  track: MediaStreamTrack,
+  info: PeerInfo
+) => void;
 
 export type CreateRoom = (
   roomId: string,

--- a/web/src/network/ipfsRoom.ts
+++ b/web/src/network/ipfsRoom.ts
@@ -28,7 +28,6 @@ export const createRoom: CreateRoom = async (
     (window as any).myConnMap = connMap;
   }
   let mediaTypes: string[] = [];
-  let localStream: MediaStream | null = null;
 
   const roomTopic = roomId.slice(0, ROOM_ID_PREFIX_LEN);
   const cryptoKey = await importCryptoKey(roomId.slice(ROOM_ID_PREFIX_LEN));
@@ -98,29 +97,34 @@ export const createRoom: CreateRoom = async (
   }
 
   const acceptMediaTypes = (mTypes: string[]) => {
-    mediaTypes = mTypes;
-    if (mediaTypes.length) {
-      if (!localStream) {
-        localStream = new MediaStream();
-        connMap.forEachConns((conn) => {
-          const info: PeerInfo = {
-            userId: conn.userId,
-            peerIndex: conn.peerIndex,
-            mediaTypes: connMap.getMediaTypes(conn),
-          };
-          conn.recvPc.getReceivers().forEach((receiver) => {
-            if (receiver.track.readyState !== "live") return;
-            receiveTrack(
-              "TODO",
-              setupTrackStopOnLongMute(receiver.track, conn.recvPc),
-              info
-            );
-          });
+    if (mTypes.length !== mediaTypes.length) {
+      connMap.forEachConns((conn) => {
+        const info: PeerInfo = {
+          userId: conn.userId,
+          peerIndex: conn.peerIndex,
+          mediaTypes: connMap.getAcceptingMediaTypes(conn),
+        };
+        const transceivers = conn.recvPc.getTransceivers();
+        conn.recvPc.getReceivers().forEach((receiver) => {
+          const transceiver = transceivers.find((t) => t.receiver === receiver);
+          const mid = transceiver?.mid;
+          const mType = mid && connMap.getRemoteMediaType(conn, mid);
+          if (!mType) {
+            console.warn("failed to find media type from mid");
+            return;
+          }
+          if (receiver.track.readyState !== "live") return;
+          if (mediaTypes.includes(mType)) return;
+          if (!mTypes.includes(mType)) return;
+          receiveTrack(
+            mType,
+            setupTrackStopOnLongMute(receiver.track, conn.recvPc),
+            info
+          );
         });
-      }
-    } else {
-      localStream = null;
+      });
     }
+    mediaTypes = mTypes;
     broadcastData(null);
   };
 
@@ -136,7 +140,8 @@ export const createRoom: CreateRoom = async (
           answer: RTCSessionDescriptionInit;
         }
   ) => {
-    await sendPayloadDirectly(conn, { SDP: sdp });
+    const msid2mediaType = getMsid2MediaType();
+    await sendPayloadDirectly(conn, { SDP: { ...sdp, msid2mediaType } });
   };
 
   const handlePayloadSDP = async (conn: Connection, sdp: unknown) => {
@@ -146,6 +151,7 @@ export const createRoom: CreateRoom = async (
       return;
     }
     const { negotiationId } = sdp;
+    connMap.registerRemoteMediaType(conn, sdp);
     if (hasObjectProp(sdp, "offer")) {
       try {
         await conn.recvPc.setRemoteDescription(sdp.offer);
@@ -225,7 +231,7 @@ export const createRoom: CreateRoom = async (
       Array.isArray(payloadMediaTypes) &&
       payloadMediaTypes.every((x) => typeof x === "string")
     ) {
-      connMap.setMediaTypes(conn, payloadMediaTypes as string[]);
+      connMap.setAcceptingMediaTypes(conn, payloadMediaTypes as string[]);
       await sleep(5000);
       syncAllTracks(conn);
     }
@@ -235,7 +241,7 @@ export const createRoom: CreateRoom = async (
     const info: PeerInfo = {
       userId: conn.userId,
       peerIndex: conn.peerIndex,
-      mediaTypes: connMap.getMediaTypes(conn),
+      mediaTypes: connMap.getAcceptingMediaTypes(conn),
     };
     try {
       receiveData(data, info);
@@ -274,13 +280,19 @@ export const createRoom: CreateRoom = async (
       }
     });
     conn.recvPc.addEventListener("track", (event: RTCTrackEvent) => {
+      const { mid } = event.transceiver;
+      const mType = mid && connMap.getRemoteMediaType(conn, mid);
+      if (!mType) {
+        console.warn("failed to find media type from mid");
+        return;
+      }
       const info: PeerInfo = {
         userId: conn.userId,
         peerIndex: conn.peerIndex,
-        mediaTypes: connMap.getMediaTypes(conn),
+        mediaTypes: connMap.getAcceptingMediaTypes(conn),
       };
       receiveTrack(
-        "TODO",
+        mType,
         setupTrackStopOnLongMute(event.track, conn.recvPc),
         info
       );
@@ -387,16 +399,29 @@ export const createRoom: CreateRoom = async (
     await ipfs.stop();
   };
 
-  const trackMediaTypeMap = new WeakMap<MediaStreamTrack, string>();
+  const mediaTypeMap = new Map<
+    string,
+    {
+      stream: MediaStream;
+      track: MediaStreamTrack;
+    }
+  >();
+
+  const getMsid2MediaType = () => {
+    const msid2mediaType: Record<string, string> = {};
+    mediaTypeMap.forEach(({ stream }, mType) => {
+      msid2mediaType[stream.id] = mType;
+    });
+    return msid2mediaType;
+  };
 
   const addTrack = (mediaType: string, track: MediaStreamTrack) => {
-    if (!localStream) return;
-    trackMediaTypeMap.set(track, mediaType);
-    localStream.addTrack(track);
+    const stream = new MediaStream();
+    stream.addTrack(track);
+    mediaTypeMap.set(mediaType, { stream, track });
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
       try {
-        if (!localStream) return;
-        conn.sendPc.addTrack(track, localStream);
+        conn.sendPc.addTrack(track, stream);
         startNegotiation(conn);
       } catch (e) {
         if (e.name === "InvalidAccessError") {
@@ -409,9 +434,7 @@ export const createRoom: CreateRoom = async (
   };
 
   const removeTrack = (mediaType: string, track: MediaStreamTrack) => {
-    if (localStream) {
-      localStream.removeTrack(track);
-    }
+    mediaTypeMap.delete(mediaType);
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
       const senders = conn.sendPc.getSenders();
       const sender = senders.find((s) => s.track === track);
@@ -424,30 +447,26 @@ export const createRoom: CreateRoom = async (
 
   const syncAllTracks = (conn: Connection) => {
     const senders = conn.sendPc.getSenders();
-    const mTypes = connMap.getMediaTypes(conn);
-    if (localStream) {
-      localStream.getTracks().forEach((track) => {
-        const mType = trackMediaTypeMap.get(track);
-        if (
-          localStream &&
-          mType &&
-          mTypes.includes(mType) &&
-          senders.every((sender) => sender.track !== track)
-        ) {
-          conn.sendPc.addTrack(track, localStream);
-          startNegotiation(conn);
-        }
-      });
-    }
-    senders.forEach((sender) => {
-      if (sender.track) {
-        const mType = trackMediaTypeMap.get(sender.track);
-        if (!mType || !mTypes.includes(mType)) {
-          conn.sendPc.removeTrack(sender);
-          startNegotiation(conn);
-        }
+    const acceptingMediaTypes = connMap.getAcceptingMediaTypes(conn);
+    acceptingMediaTypes.forEach((mType) => {
+      const item = mediaTypeMap.get(mType);
+      if (!item) return;
+      const { stream, track } = item;
+      if (senders.every((sender) => sender.track !== track)) {
+        conn.sendPc.addTrack(track, stream);
       }
     });
+    senders.forEach((sender) => {
+      if (!sender.track) return;
+      const isEffective = acceptingMediaTypes.some(
+        (mType) => mediaTypeMap.get(mType)?.track === sender.track
+      );
+      if (isEffective) return;
+      conn.sendPc.removeTrack(sender);
+    });
+    if (senders.some((sender) => sender.track && !sender.transport)) {
+      conn.sendPc.dispatchEvent(new Event("negotiationneeded"));
+    }
   };
 
   const dispose = async () => {

--- a/web/src/network/ipfsRoom.ts
+++ b/web/src/network/ipfsRoom.ts
@@ -454,6 +454,7 @@ export const createRoom: CreateRoom = async (
       const { stream, track } = item;
       if (senders.every((sender) => sender.track !== track)) {
         conn.sendPc.addTrack(track, stream);
+        startNegotiation(conn);
       }
     });
     senders.forEach((sender) => {
@@ -463,10 +464,8 @@ export const createRoom: CreateRoom = async (
       );
       if (isEffective) return;
       conn.sendPc.removeTrack(sender);
+      startNegotiation(conn);
     });
-    if (senders.some((sender) => sender.track && !sender.transport)) {
-      conn.sendPc.dispatchEvent(new Event("negotiationneeded"));
-    }
   };
 
   const dispose = async () => {

--- a/web/src/network/ipfsRoom.ts
+++ b/web/src/network/ipfsRoom.ts
@@ -416,8 +416,8 @@ export const createRoom: CreateRoom = async (
   };
 
   const addTrack = (mediaType: string, track: MediaStreamTrack) => {
-    const stream = new MediaStream();
-    stream.addTrack(track);
+    removeTrack(mediaType);
+    const stream = new MediaStream([track]);
     mediaTypeMap.set(mediaType, { stream, track });
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
       try {
@@ -433,7 +433,10 @@ export const createRoom: CreateRoom = async (
     });
   };
 
-  const removeTrack = (mediaType: string, track: MediaStreamTrack) => {
+  const removeTrack = (mediaType: string) => {
+    const item = mediaTypeMap.get(mediaType);
+    if (!item) return;
+    const { track } = item;
     mediaTypeMap.delete(mediaType);
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
       const senders = conn.sendPc.getSenders();

--- a/web/src/network/ipfsRoom.ts
+++ b/web/src/network/ipfsRoom.ts
@@ -465,9 +465,10 @@ export const createRoom: CreateRoom = async (
       const isEffective = acceptingMediaTypes.some(
         (mType) => mediaTypeMap.get(mType)?.track === sender.track
       );
-      if (isEffective) return;
-      conn.sendPc.removeTrack(sender);
-      startNegotiation(conn);
+      if (!isEffective) {
+        conn.sendPc.removeTrack(sender);
+        startNegotiation(conn);
+      }
     });
   };
 

--- a/web/src/network/ipfsRoom.ts
+++ b/web/src/network/ipfsRoom.ts
@@ -113,14 +113,17 @@ export const createRoom: CreateRoom = async (
             console.warn("failed to find media type from mid");
             return;
           }
-          if (receiver.track.readyState !== "live") return;
-          if (mediaTypes.includes(mType)) return;
-          if (!mTypes.includes(mType)) return;
-          receiveTrack(
-            mType,
-            setupTrackStopOnLongMute(receiver.track, conn.recvPc),
-            info
-          );
+          if (
+            receiver.track.readyState === "live" &&
+            !mediaTypes.includes(mType) &&
+            mTypes.includes(mType)
+          ) {
+            receiveTrack(
+              mType,
+              setupTrackStopOnLongMute(receiver.track, conn.recvPc),
+              info
+            );
+          }
         });
       });
     }
@@ -416,7 +419,9 @@ export const createRoom: CreateRoom = async (
   };
 
   const addTrack = (mediaType: string, track: MediaStreamTrack) => {
-    removeTrack(mediaType);
+    if (mediaTypeMap.has(mediaType)) {
+      throw new Error(`track is already added for ${mediaType}`);
+    }
     const stream = new MediaStream([track]);
     mediaTypeMap.set(mediaType, { stream, track });
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
@@ -435,7 +440,10 @@ export const createRoom: CreateRoom = async (
 
   const removeTrack = (mediaType: string) => {
     const item = mediaTypeMap.get(mediaType);
-    if (!item) return;
+    if (!item) {
+      console.log("track is already removed for", mediaType);
+      return;
+    }
     const { track } = item;
     mediaTypeMap.delete(mediaType);
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {

--- a/web/src/network/ipfsRoom.ts
+++ b/web/src/network/ipfsRoom.ts
@@ -111,6 +111,7 @@ export const createRoom: CreateRoom = async (
           conn.recvPc.getReceivers().forEach((receiver) => {
             if (receiver.track.readyState !== "live") return;
             receiveTrack(
+              "TODO",
               setupTrackStopOnLongMute(receiver.track, conn.recvPc),
               info
             );
@@ -278,7 +279,11 @@ export const createRoom: CreateRoom = async (
         peerIndex: conn.peerIndex,
         mediaTypes: connMap.getMediaTypes(conn),
       };
-      receiveTrack(setupTrackStopOnLongMute(event.track, conn.recvPc), info);
+      receiveTrack(
+        "TODO",
+        setupTrackStopOnLongMute(event.track, conn.recvPc),
+        info
+      );
     });
     notifyNewPeer(conn.peerIndex);
     updateNetworkStatus({

--- a/web/src/network/peerjsRoom.ts
+++ b/web/src/network/peerjsRoom.ts
@@ -418,8 +418,8 @@ export const createRoom: CreateRoom = async (
   };
 
   const addTrack = (mediaType: string, track: MediaStreamTrack) => {
-    const stream = new MediaStream();
-    stream.addTrack(track);
+    removeTrack(mediaType);
+    const stream = new MediaStream([track]);
     mediaTypeMap.set(mediaType, { stream, track });
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
       try {
@@ -434,7 +434,10 @@ export const createRoom: CreateRoom = async (
     });
   };
 
-  const removeTrack = (mediaType: string, track: MediaStreamTrack) => {
+  const removeTrack = (mediaType: string) => {
+    const item = mediaTypeMap.get(mediaType);
+    if (!item) return;
+    const { track } = item;
     mediaTypeMap.delete(mediaType);
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
       const senders = conn.peerConnection.getSenders();

--- a/web/src/network/peerjsRoom.ts
+++ b/web/src/network/peerjsRoom.ts
@@ -3,7 +3,7 @@ import Peer from "peerjs";
 import { sleep } from "../utils/sleep";
 import { rand4, importCryptoKey, encrypt, decrypt } from "../utils/crypto";
 import { getPeerJsConfigFromUrl } from "../utils/url";
-import { isObject } from "../utils/types";
+import { isObject, hasObjectProp } from "../utils/types";
 import { ROOM_ID_PREFIX_LEN, PeerInfo, CreateRoom } from "./common";
 import {
   isValidPeerId,
@@ -33,7 +33,6 @@ export const createRoom: CreateRoom = async (
   let myPeer: Peer | null = null;
   const connMap = createConnectionMap();
   let mediaTypes: string[] = [];
-  let localStream: MediaStream | null = null;
 
   const cryptoKey = await importCryptoKey(roomId.slice(ROOM_ID_PREFIX_LEN));
 
@@ -70,16 +69,20 @@ export const createRoom: CreateRoom = async (
     sendPayload(conn, { userId, data, peers, mediaTypes });
   };
 
-  const sendSDP = (conn: Peer.DataConnection, sdp: unknown) => {
-    sendPayload(conn, { SDP: sdp });
+  const sendSDP = (
+    conn: Peer.DataConnection,
+    sdp: { offer: unknown } | { answer: unknown }
+  ) => {
+    const msid2mediaType = getMsid2MediaType();
+    sendPayload(conn, { SDP: { ...sdp, msid2mediaType } });
   };
 
   const handlePayloadSDP = async (conn: Peer.DataConnection, sdp: unknown) => {
     if (!isObject(sdp)) return;
-    if (isObject((sdp as { offer: unknown }).offer)) {
-      const { offer } = sdp as { offer: object };
+    connMap.registerRemoteMediaType(conn, sdp);
+    if (hasObjectProp(sdp, "offer")) {
       try {
-        await conn.peerConnection.setRemoteDescription(offer as any);
+        await conn.peerConnection.setRemoteDescription(sdp.offer as any);
         syncAllTracks(conn);
         const answer = await conn.peerConnection.createAnswer();
         await conn.peerConnection.setLocalDescription(answer);
@@ -87,10 +90,9 @@ export const createRoom: CreateRoom = async (
       } catch (e) {
         console.info("handleSDP offer failed", e);
       }
-    } else if (isObject((sdp as { answer: unknown }).answer)) {
-      const { answer } = sdp as { answer: object };
+    } else if (hasObjectProp(sdp, "answer")) {
       try {
-        await conn.peerConnection.setRemoteDescription(answer as any);
+        await conn.peerConnection.setRemoteDescription(sdp.answer as any);
       } catch (e) {
         console.info("handleSDP answer failed", e);
         await sleep(Math.random() * 30 * 1000);
@@ -119,7 +121,7 @@ export const createRoom: CreateRoom = async (
       Array.isArray(payloadMediaTypes) &&
       payloadMediaTypes.every((x) => typeof x === "string")
     ) {
-      connMap.setMediaTypes(conn, payloadMediaTypes as string[]);
+      connMap.setAcceptingMediaTypes(conn, payloadMediaTypes as string[]);
       await sleep(5000);
       syncAllTracks(conn);
     }
@@ -141,7 +143,7 @@ export const createRoom: CreateRoom = async (
       const info: PeerInfo = {
         userId: connUserId,
         peerIndex: getPeerIndexFromConn(conn),
-        mediaTypes: connMap.getMediaTypes(conn),
+        mediaTypes: connMap.getAcceptingMediaTypes(conn),
       };
       try {
         receiveData(data, info);
@@ -215,14 +217,21 @@ export const createRoom: CreateRoom = async (
       sendSDP(conn, { offer });
     });
     conn.peerConnection.addEventListener("track", (event: RTCTrackEvent) => {
+      const { mid } = event.transceiver;
+      const mType = mid && connMap.getRemoteMediaType(conn, mid);
+      if (!mType) {
+        console.warn("failed to find media type from mid");
+        return;
+      }
       const connUserId = connMap.getUserId(conn);
       if (connUserId) {
         const info: PeerInfo = {
           userId: connUserId,
           peerIndex: getPeerIndexFromPeerId(conn.peer),
-          mediaTypes: connMap.getMediaTypes(conn),
+          mediaTypes: connMap.getAcceptingMediaTypes(conn),
         };
         receiveTrack(
+          mType,
           setupTrackStopOnLongMute(event.track, conn.peerConnection),
           info
         );
@@ -356,44 +365,65 @@ export const createRoom: CreateRoom = async (
   };
 
   const acceptMediaTypes = (mTypes: string[]) => {
-    mediaTypes = mTypes;
-    if (mediaTypes.length) {
-      if (!localStream) {
-        localStream = new MediaStream();
-        connMap.forEachConnectedConns((conn) => {
-          const connUserId = connMap.getUserId(conn);
-          if (connUserId) {
-            const info: PeerInfo = {
-              userId: connUserId,
-              peerIndex: getPeerIndexFromPeerId(conn.peer),
-              mediaTypes: connMap.getMediaTypes(conn),
-            };
-            conn.peerConnection.getReceivers().forEach((receiver) => {
-              if (receiver.track.readyState !== "live") return;
-              receiveTrack(
-                setupTrackStopOnLongMute(receiver.track, conn.peerConnection),
-                info
-              );
-            });
-          }
-        });
-      }
-    } else {
-      localStream = null;
+    if (mTypes.length !== mediaTypes.length) {
+      connMap.forEachConnectedConns((conn) => {
+        const connUserId = connMap.getUserId(conn);
+        if (connUserId) {
+          const info: PeerInfo = {
+            userId: connUserId,
+            peerIndex: getPeerIndexFromPeerId(conn.peer),
+            mediaTypes: connMap.getAcceptingMediaTypes(conn),
+          };
+          const transceivers = conn.peerConnection.getTransceivers();
+          conn.peerConnection.getReceivers().forEach((receiver) => {
+            const transceiver = transceivers.find(
+              (t) => t.receiver === receiver
+            );
+            const mid = transceiver?.mid;
+            const mType = mid && connMap.getRemoteMediaType(conn, mid);
+            if (!mType) {
+              console.warn("failed to find media type from mid");
+              return;
+            }
+            if (receiver.track.readyState !== "live") return;
+            if (mediaTypes.includes(mType)) return;
+            if (!mTypes.includes(mType)) return;
+            receiveTrack(
+              mType,
+              setupTrackStopOnLongMute(receiver.track, conn.peerConnection),
+              info
+            );
+          });
+        }
+      });
     }
+    mediaTypes = mTypes;
     broadcastData(null);
   };
 
-  const trackMediaTypeMap = new WeakMap<MediaStreamTrack, string>();
+  const mediaTypeMap = new Map<
+    string,
+    {
+      stream: MediaStream;
+      track: MediaStreamTrack;
+    }
+  >();
+
+  const getMsid2MediaType = () => {
+    const msid2mediaType: Record<string, string> = {};
+    mediaTypeMap.forEach(({ stream }, mType) => {
+      msid2mediaType[stream.id] = mType;
+    });
+    return msid2mediaType;
+  };
 
   const addTrack = (mediaType: string, track: MediaStreamTrack) => {
-    if (!localStream) return;
-    trackMediaTypeMap.set(track, mediaType);
-    localStream.addTrack(track);
+    const stream = new MediaStream();
+    stream.addTrack(track);
+    mediaTypeMap.set(mediaType, { stream, track });
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
       try {
-        if (!localStream) return;
-        conn.peerConnection.addTrack(track, localStream);
+        conn.peerConnection.addTrack(track, stream);
       } catch (e) {
         if (e.name === "InvalidAccessError") {
           // ignore
@@ -405,9 +435,7 @@ export const createRoom: CreateRoom = async (
   };
 
   const removeTrack = (mediaType: string, track: MediaStreamTrack) => {
-    if (localStream) {
-      localStream.removeTrack(track);
-    }
+    mediaTypeMap.delete(mediaType);
     connMap.forEachConnsAcceptingMedia(mediaType, (conn) => {
       const senders = conn.peerConnection.getSenders();
       const sender = senders.find((s) => s.track === track);
@@ -419,27 +447,22 @@ export const createRoom: CreateRoom = async (
 
   const syncAllTracks = (conn: Peer.DataConnection) => {
     const senders = conn.peerConnection.getSenders();
-    const mTypes = connMap.getMediaTypes(conn);
-    if (localStream) {
-      localStream.getTracks().forEach((track) => {
-        const mType = trackMediaTypeMap.get(track);
-        if (
-          localStream &&
-          mType &&
-          mTypes.includes(mType) &&
-          senders.every((sender) => sender.track !== track)
-        ) {
-          conn.peerConnection.addTrack(track, localStream);
-        }
-      });
-    }
-    senders.forEach((sender) => {
-      if (sender.track) {
-        const mType = trackMediaTypeMap.get(sender.track);
-        if (!mType || !mTypes.includes(mType)) {
-          conn.peerConnection.removeTrack(sender);
-        }
+    const acceptingMediaTypes = connMap.getAcceptingMediaTypes(conn);
+    acceptingMediaTypes.forEach((mType) => {
+      const item = mediaTypeMap.get(mType);
+      if (!item) return;
+      const { stream, track } = item;
+      if (senders.every((sender) => sender.track !== track)) {
+        conn.peerConnection.addTrack(track, stream);
       }
+    });
+    senders.forEach((sender) => {
+      if (!sender.track) return;
+      const isEffective = acceptingMediaTypes.some(
+        (mType) => mediaTypeMap.get(mType)?.track === sender.track
+      );
+      if (isEffective) return;
+      conn.peerConnection.removeTrack(sender);
     });
     if (senders.some((sender) => sender.track && !sender.transport)) {
       conn.peerConnection.dispatchEvent(new Event("negotiationneeded"));

--- a/web/src/network/peerjsRoom.ts
+++ b/web/src/network/peerjsRoom.ts
@@ -82,7 +82,7 @@ export const createRoom: CreateRoom = async (
     connMap.registerRemoteMediaType(conn, sdp);
     if (hasObjectProp(sdp, "offer")) {
       try {
-        await conn.peerConnection.setRemoteDescription(sdp.offer as any);
+        await conn.peerConnection.setRemoteDescription(sdp.offer);
         syncAllTracks(conn);
         const answer = await conn.peerConnection.createAnswer();
         await conn.peerConnection.setLocalDescription(answer);
@@ -92,7 +92,7 @@ export const createRoom: CreateRoom = async (
       }
     } else if (hasObjectProp(sdp, "answer")) {
       try {
-        await conn.peerConnection.setRemoteDescription(sdp.answer as any);
+        await conn.peerConnection.setRemoteDescription(sdp.answer);
       } catch (e) {
         console.info("handleSDP answer failed", e);
         await sleep(Math.random() * 30 * 1000);

--- a/web/src/network/peerjsUtils.ts
+++ b/web/src/network/peerjsUtils.ts
@@ -29,6 +29,22 @@ export const createConnectionMap = () => {
   };
   const map = new Map<string, Value>();
 
+  const setAcceptingMediaTypes = (
+    conn: Peer.DataConnection,
+    mediaTypes: string[]
+  ) => {
+    const value = map.get(conn.peer);
+    if (value) {
+      value.acceptingMediaTypes = mediaTypes;
+    }
+  };
+
+  const getAcceptingMediaTypes = (conn: Peer.DataConnection) => {
+    const value = map.get(conn.peer);
+    if (!value) return [];
+    return value.acceptingMediaTypes;
+  };
+
   const addConn = (conn: Peer.DataConnection) => {
     const value = map.get(conn.peer);
     if (value) {
@@ -63,22 +79,6 @@ export const createConnectionMap = () => {
   const getUserId = (conn: Peer.DataConnection) => {
     const value = map.get(conn.peer);
     return value && value.userId;
-  };
-
-  const setAcceptingMediaTypes = (
-    conn: Peer.DataConnection,
-    mediaTypes: string[]
-  ) => {
-    const value = map.get(conn.peer);
-    if (value) {
-      value.acceptingMediaTypes = mediaTypes;
-    }
-  };
-
-  const getAcceptingMediaTypes = (conn: Peer.DataConnection) => {
-    const value = map.get(conn.peer);
-    if (!value) return [];
-    return value.acceptingMediaTypes;
   };
 
   const hasConn = (peerId: string) => map.has(peerId);
@@ -171,13 +171,13 @@ export const createConnectionMap = () => {
   };
 
   return {
+    setAcceptingMediaTypes,
+    getAcceptingMediaTypes,
     addConn,
     markConnected,
     isConnected,
     setUserId,
     getUserId,
-    setAcceptingMediaTypes,
-    getAcceptingMediaTypes,
     hasConn,
     getConn,
     delConn,

--- a/web/src/network/peerjsUtils.ts
+++ b/web/src/network/peerjsUtils.ts
@@ -1,6 +1,7 @@
 import Peer from "peerjs";
 
 import { ROOM_ID_PREFIX_LEN } from "./common";
+import { hasObjectProp, hasStringProp } from "../utils/types";
 
 export const isValidPeerId = (
   roomId: string,
@@ -23,7 +24,8 @@ export const createConnectionMap = () => {
     conn: Peer.DataConnection;
     connected?: boolean;
     userId?: string;
-    mediaTypes: string[];
+    acceptingMediaTypes: string[];
+    remoteMediaTypes: Record<string, string>; // key = mid
   };
   const map = new Map<string, Value>();
 
@@ -32,7 +34,11 @@ export const createConnectionMap = () => {
     if (value) {
       value.conn.close();
     }
-    map.set(conn.peer, { conn, mediaTypes: [] });
+    map.set(conn.peer, {
+      conn,
+      acceptingMediaTypes: [],
+      remoteMediaTypes: {},
+    });
   };
 
   const markConnected = (conn: Peer.DataConnection) => {
@@ -59,16 +65,20 @@ export const createConnectionMap = () => {
     return value && value.userId;
   };
 
-  const setMediaTypes = (conn: Peer.DataConnection, mediaTypes: string[]) => {
+  const setAcceptingMediaTypes = (
+    conn: Peer.DataConnection,
+    mediaTypes: string[]
+  ) => {
     const value = map.get(conn.peer);
     if (value) {
-      value.mediaTypes = mediaTypes;
+      value.acceptingMediaTypes = mediaTypes;
     }
   };
 
-  const getMediaTypes = (conn: Peer.DataConnection) => {
+  const getAcceptingMediaTypes = (conn: Peer.DataConnection) => {
     const value = map.get(conn.peer);
-    return (value && value.mediaTypes) || [];
+    if (!value) return [];
+    return value.acceptingMediaTypes;
   };
 
   const hasConn = (peerId: string) => map.has(peerId);
@@ -104,11 +114,7 @@ export const createConnectionMap = () => {
     callback: (conn: Peer.DataConnection) => void
   ) => {
     Array.from(map.values()).forEach((value) => {
-      if (
-        value.connected &&
-        value.mediaTypes &&
-        value.mediaTypes.includes(mediaType)
-      ) {
+      if (value.connected && value.acceptingMediaTypes.includes(mediaType)) {
         callback(value.conn);
       }
     });
@@ -121,14 +127,57 @@ export const createConnectionMap = () => {
     map.clear();
   };
 
+  const getRemoteMediaType = (conn: Peer.DataConnection, mid: string) => {
+    const value = map.get(conn.peer);
+    if (!value) return null;
+    return value.remoteMediaTypes[mid] || null;
+  };
+
+  const registerRemoteMediaTypeFromSDP = (
+    conn: Peer.DataConnection,
+    msid2mediaType: Record<string, unknown>,
+    sdpLines: string
+  ) => {
+    const value = map.get(conn.peer);
+    if (!value) return;
+    const lines = sdpLines.split(/[\r\n]+/);
+    let mid: string;
+    lines.forEach((line) => {
+      if (line.startsWith("a=mid:")) {
+        mid = line.slice("a=mid:".length);
+      } else if (line.startsWith("a=msid:")) {
+        const arr = line.slice("a=msid:".length).split(" ");
+        arr.forEach((msid) => {
+          const mediaType = msid2mediaType[msid];
+          if (typeof mediaType === "string") {
+            value.remoteMediaTypes[mid] = mediaType;
+          }
+        });
+      }
+    });
+  };
+
+  const registerRemoteMediaType = (
+    conn: Peer.DataConnection,
+    sdp: Record<string, unknown>
+  ) => {
+    if (!hasObjectProp(sdp, "msid2mediaType")) return;
+    if (hasObjectProp(sdp, "offer") && hasStringProp(sdp.offer, "sdp")) {
+      registerRemoteMediaTypeFromSDP(conn, sdp.msid2mediaType, sdp.offer.sdp);
+    }
+    if (hasObjectProp(sdp, "answer") && hasStringProp(sdp.answer, "sdp")) {
+      registerRemoteMediaTypeFromSDP(conn, sdp.msid2mediaType, sdp.answer.sdp);
+    }
+  };
+
   return {
     addConn,
     markConnected,
     isConnected,
     setUserId,
     getUserId,
-    setMediaTypes,
-    getMediaTypes,
+    setAcceptingMediaTypes,
+    getAcceptingMediaTypes,
     hasConn,
     getConn,
     delConn,
@@ -136,5 +185,7 @@ export const createConnectionMap = () => {
     forEachConnectedConns,
     forEachConnsAcceptingMedia,
     clearAll,
+    getRemoteMediaType,
+    registerRemoteMediaType,
   };
 };

--- a/web/src/network/pubsubRoom.ts
+++ b/web/src/network/pubsubRoom.ts
@@ -160,7 +160,11 @@ export const createRoom: CreateRoom = async (
             };
             c.worker = worker;
             const audioTrack = destination.stream.getAudioTracks()[0];
-            receiveTrack(await loopbackPeerConnection(audioTrack), info);
+            receiveTrack(
+              "faceAudio",
+              await loopbackPeerConnection(audioTrack),
+              info
+            );
             faceAudioDisposeList.push(() => {
               audioCtx.close();
               audioTrack.dispatchEvent(new Event("ended"));
@@ -204,6 +208,7 @@ export const createRoom: CreateRoom = async (
           conn.recvPc.getReceivers().forEach((receiver) => {
             if (receiver.track.readyState !== "live") return;
             receiveTrack(
+              "TODO",
               setupTrackStopOnLongMute(receiver.track, conn.recvPc),
               info
             );
@@ -371,7 +376,11 @@ export const createRoom: CreateRoom = async (
         peerIndex: conn.peerIndex,
         mediaTypes: connMap.getMediaTypes(conn),
       };
-      receiveTrack(setupTrackStopOnLongMute(event.track, conn.recvPc), info);
+      receiveTrack(
+        "TODO",
+        setupTrackStopOnLongMute(event.track, conn.recvPc),
+        info
+      );
     });
     notifyNewPeer(conn.peerIndex);
     updateNetworkStatus({

--- a/web/src/network/pubsubRoom.ts
+++ b/web/src/network/pubsubRoom.ts
@@ -588,9 +588,10 @@ export const createRoom: CreateRoom = async (
       const isEffective = acceptingMediaTypes.some(
         (mType) => mediaTypeMap.get(mType)?.track === sender.track
       );
-      if (isEffective) return;
-      conn.sendPc.removeTrack(sender);
-      startNegotiation(conn);
+      if (!isEffective) {
+        conn.sendPc.removeTrack(sender);
+        startNegotiation(conn);
+      }
     });
   };
 

--- a/web/src/network/pubsubRoom.ts
+++ b/web/src/network/pubsubRoom.ts
@@ -579,6 +579,7 @@ export const createRoom: CreateRoom = async (
       const { stream, track } = item;
       if (senders.every((sender) => sender.track !== track)) {
         conn.sendPc.addTrack(track, stream);
+        startNegotiation(conn);
       }
     });
     senders.forEach((sender) => {
@@ -588,10 +589,8 @@ export const createRoom: CreateRoom = async (
       );
       if (isEffective) return;
       conn.sendPc.removeTrack(sender);
+      startNegotiation(conn);
     });
-    if (senders.some((sender) => sender.track && !sender.transport)) {
-      conn.sendPc.dispatchEvent(new Event("negotiationneeded"));
-    }
   };
 
   const dispose = async () => {

--- a/web/src/utils/types.ts
+++ b/web/src/utils/types.ts
@@ -1,16 +1,22 @@
-export const isObject = (x: unknown): x is object =>
+export const isObject = (x: unknown): x is Record<string, unknown> =>
   typeof x === "object" && x !== null;
 
-export const hasStringProp = <Prop extends string>(
-  x: object,
+export const hasStringProp = <
+  Obj extends Record<string, unknown>,
+  Prop extends string
+>(
+  x: Obj,
   prop: Prop
-): x is object & Record<Prop, string> =>
+): x is Obj & Record<Prop, string> =>
   typeof (x as Record<Prop, unknown>)[prop] === "string";
 
-export const hasObjectProp = <Prop extends string>(
-  x: object,
+export const hasObjectProp = <
+  Obj extends Record<string, unknown>,
+  Prop extends string
+>(
+  x: Obj,
   prop: Prop
-): x is object & Record<Prop, object> =>
+): x is Obj & Record<Prop, Record<string, unknown>> =>
   isObject((x as Record<Prop, unknown>)[prop]);
 
 export type ReturnPromiseType<F extends (...args: any) => any> = ReturnType<


### PR DESCRIPTION
We parse SDP and relate mid and msid, and mediaType.

This is a breaking change in network, and not compatible with previous versions.